### PR TITLE
workout 名を編集しなかったら何もしない

### DIFF
--- a/app/javascript/packs/workout_entries.js
+++ b/app/javascript/packs/workout_entries.js
@@ -1,9 +1,10 @@
 // TODO: 入力して、フォーカスが外れたら、フォームに値を書き込む
 
-// function updateFormValue(idValue, workoutNameValue) {
 function updateFormValue() {
     let updatingValue = this.parentNode.querySelector('input').value
     let updatingId = this.parentNode.querySelector('input').dataset.id
+
+    if (updatingValue === '') { return }
 
     let valueTarget = document.querySelector('#workout_name')
     let idTarget = document.querySelector('#id')
@@ -38,6 +39,8 @@ function hideInput() {
 }
 
 function updateSpanValue(context, value) {
+    if (value === '') { return }
+
     context.parentNode.querySelector('span').textContent = value
 }
 


### PR DESCRIPTION
# 対象

`admin/workouts/monthly/:year/:month` ページのワークアウト名編集機能

# 問題

クリックで出現させた `<input/>` に何も入力しなかった場合に、空の値としてワークアウト名が更新されてしまう

# 対応

入力内容が空だった場合に何もしないよう動作を変更